### PR TITLE
fix: move deps to dev deps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,10 +8,8 @@
       "name": "expo-color-space-plugin",
       "version": "1.0.0",
       "license": "MIT",
-      "dependencies": {
-        "@expo/config-plugins": "^7.0.0"
-      },
       "devDependencies": {
+        "@expo/config-plugins": "^7.0.0",
         "@types/node": "^18.0.0",
         "expo-module-scripts": "^5.0.7",
         "typescript": "^5.0.0"

--- a/package.json
+++ b/package.json
@@ -29,10 +29,8 @@
   "author": "Enzo Manuel Mangano <enzomanuelmangano@gmail.com> (https://github.com/enzomanuelmangano)",
   "license": "MIT",
   "homepage": "https://github.com/enzomanuelmangano/expo-color-space-plugin#readme",
-  "dependencies": {
-    "@expo/config-plugins": "^7.0.0"
-  },
   "devDependencies": {
+    "@expo/config-plugins": "^7.0.0",
     "expo-module-scripts": "^5.0.7",
     "typescript": "^5.0.0",
     "@types/node": "^18.0.0"


### PR DESCRIPTION
Move a hard required dependency on `@expo/config-plugins` to dev dependency while relying on the config plugin of the project the package is executing on.